### PR TITLE
feat: do not allow whitespace between comparison operator and expression

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -125,7 +125,7 @@ post_boolean_primary ->
   | __ boolean_primary {% d => d[1] %}
 
 side ->
-    field relational_operator _ tag_expression {% (data, start) => {
+    field relational_operator tag_expression {% (data, start) => {
     const field = {
       type: 'Field',
       name: data[0].name,
@@ -142,11 +142,11 @@ side ->
     return {
       location: {
         start,
-        end: data[3].expression.location.end,
+        end: data[2].expression.location.end,
       },
       field,
       operator: data[1],
-      ...data[3]
+      ...data[2]
     }
   } %}
   | tag_expression {% (data, start) => {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -143,7 +143,7 @@ const grammar: Grammar = {
     {"name": "boolean_primary", "symbols": ["side"], "postprocess": id},
     {"name": "post_boolean_primary", "symbols": ["__", "parentheses_open", "_", "two_op_logical_expression", "_", "parentheses_close"], "postprocess": d => ({location: {start: d[1].location.start, end: d[5].location.start + 1, }, type: 'ParenthesizedExpression', expression: d[3]})},
     {"name": "post_boolean_primary", "symbols": ["__", "boolean_primary"], "postprocess": d => d[1]},
-    {"name": "side", "symbols": ["field", "relational_operator", "_", "tag_expression"], "postprocess":  (data, start) => {
+    {"name": "side", "symbols": ["field", "relational_operator", "tag_expression"], "postprocess":  (data, start) => {
           const field = {
             type: 'Field',
             name: data[0].name,
@@ -160,11 +160,11 @@ const grammar: Grammar = {
           return {
             location: {
               start,
-              end: data[3].expression.location.end,
+              end: data[2].expression.location.end,
             },
             field,
             operator: data[1],
-            ...data[3]
+            ...data[2]
           }
         } },
     {"name": "side", "symbols": ["tag_expression"], "postprocess":  (data, start) => {

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -27,8 +27,10 @@ test('error describes offset', (t) => {
 
 // TODO not clear what the expected behavior is here
 // Ideally we don't want to throw an error.
+// https://github.com/gajus/liqe/issues/18
 test.todo('empty query');
 test.todo('()');
+test.todo('foo:');
 
 test('foo', testQuery, {
   expression: {
@@ -300,7 +302,9 @@ test('foo:bar', testQuery, {
   type: 'TagExpression',
 });
 
-test('foo: bar', testQuery, {
+// https://github.com/gajus/liqe/issues/18
+// https://github.com/gajus/liqe/issues/19
+test.skip('foo: bar', testQuery, {
   expression: {
     location: {
       end: 8,
@@ -405,7 +409,9 @@ test('foo:=123', testQuery, {
   type: 'TagExpression',
 });
 
-test('foo:= 123', testQuery, {
+// https://github.com/gajus/liqe/issues/18
+// https://github.com/gajus/liqe/issues/19
+test.skip('foo:= 123', testQuery, {
   expression: {
     location: {
       end: 9,

--- a/test/liqe/serialize.ts
+++ b/test/liqe/serialize.ts
@@ -38,13 +38,17 @@ test('/[^.:@\\s](?:[^:@\\s]*[^.:@\\s])?@[^.@\\s]+(?:\\.[^.@\\s]+)*/', testQuery)
 
 test('foo:bar', testQuery);
 
-test('foo: bar', testQuery);
+// https://github.com/gajus/liqe/issues/18
+// https://github.com/gajus/liqe/issues/19
+test.skip('foo: bar', testQuery);
 
 test('foo:123', testQuery);
 
 test('foo:=123', testQuery);
 
-test('foo:= 123', testQuery);
+// https://github.com/gajus/liqe/issues/18
+// https://github.com/gajus/liqe/issues/19
+test.skip('foo:= 123', testQuery);
 
 test('foo:=-123', testQuery);
 


### PR DESCRIPTION
* https://github.com/gajus/liqe/issues/18
* https://github.com/gajus/liqe/issues/19

BREAKING CHANGE: does not allow whitespace between comparison and expression