### PR TITLE
Allow empty expression (fixes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ serialize(tokens);
 import {
   type BooleanOperatorToken,
   type ComparisonOperatorToken,
+  type EmptyExpression,
   type FieldToken,
   type ImplicitBooleanOperatorToken,
   type ImplicitFieldToken,

--- a/src/Liqe.ts
+++ b/src/Liqe.ts
@@ -13,6 +13,7 @@ export {
 export {
   BooleanOperatorToken,
   ComparisonOperatorToken,
+  EmptyExpression,
   ExpressionToken,
   FieldToken,
   Highlight,

--- a/src/createStringTest.ts
+++ b/src/createStringTest.ts
@@ -44,6 +44,10 @@ export const createStringTest = (regexCache: RegExpCache, ast: HydratedAst) => {
     return createRegexTest(regexCache, expression.value);
   }
 
+  if (expression.type !== 'LiteralExpression') {
+    throw new Error('Expected a literal expression.');
+  }
+
   const value = String(expression.value);
 
   if (value.includes('*') && expression.quoted === false) {

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -78,7 +78,14 @@ pre_two_op_logical_expression ->
   | parentheses_open _ two_op_logical_expression _ parentheses_close {% d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]}) %}
 
 one_op_logical_expression ->
-    parentheses_open _ two_op_logical_expression _ parentheses_close {% d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]}) %}
+    parentheses_open _ parentheses_close {% d => ({location: {start: d[0].location.start, end: d[2].location.start + 1, },type: 'ParenthesizedExpression', expression: {
+      type: 'EmptyExpression',
+      location: {
+        start: d[0].location.start + 1,
+        end: d[0].location.start + 1,
+      },
+    }}) %}
+  | parentheses_open _ two_op_logical_expression _ parentheses_close {% d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]}) %}
 	|	"NOT" post_boolean_primary {% (data, start) => {
   return {
     type: 'UnaryOperator',

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -125,6 +125,7 @@ post_boolean_primary ->
   | __ boolean_primary {% d => d[1] %}
 
 tag_expression ->
+    
     field comparison_operator expression {% (data, start) => {
     const field = {
       type: 'Field',
@@ -147,6 +148,37 @@ tag_expression ->
       field,
       operator: data[1],
       ...data[2]
+    }
+  } %}
+  | field comparison_operator {% (data, start) => {
+    const field = {
+      type: 'Field',
+      name: data[0].name,
+      path: data[0].name.split('.').filter(Boolean),
+      quoted: data[0].quoted,
+      quotes: data[0].quotes,
+      location: data[0].location,
+    };
+
+    if (!data[0].quotes) {
+      delete field.quotes;
+    }
+
+    return {
+      type: 'Tag',
+      location: {
+        start,
+        end: data[1].location.end,
+      },
+      field,
+      operator: data[1],
+      expression: {
+        type: 'EmptyExpression',
+        location: {
+          start: data[1].location.end,
+          end: data[1].location.end,
+        },
+      }
     }
   } %}
   | expression {% (data, start) => {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -167,6 +167,37 @@ const grammar: Grammar = {
             ...data[2]
           }
         } },
+    {"name": "tag_expression", "symbols": ["field", "comparison_operator"], "postprocess":  (data, start) => {
+          const field = {
+            type: 'Field',
+            name: data[0].name,
+            path: data[0].name.split('.').filter(Boolean),
+            quoted: data[0].quoted,
+            quotes: data[0].quotes,
+            location: data[0].location,
+          };
+        
+          if (!data[0].quotes) {
+            delete field.quotes;
+          }
+        
+          return {
+            type: 'Tag',
+            location: {
+              start,
+              end: data[1].location.end,
+            },
+            field,
+            operator: data[1],
+            expression: {
+              type: 'EmptyExpression',
+              location: {
+                start: data[1].location.end,
+                end: data[1].location.end,
+              },
+            }
+          }
+        } },
     {"name": "tag_expression", "symbols": ["expression"], "postprocess":  (data, start) => {
           return {location: {start, end: data[0].expression.location.end}, field: {type: 'ImplicitField'}, ...data[0]};
         } },

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -107,6 +107,13 @@ const grammar: Grammar = {
     {"name": "post_one_op_implicit_logical_expression", "symbols": ["parentheses_open", "_", "one_op_logical_expression", "_", "parentheses_close"], "postprocess": d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]})},
     {"name": "pre_two_op_logical_expression", "symbols": ["two_op_logical_expression", "__"], "postprocess": d => d[0]},
     {"name": "pre_two_op_logical_expression", "symbols": ["parentheses_open", "_", "two_op_logical_expression", "_", "parentheses_close"], "postprocess": d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]})},
+    {"name": "one_op_logical_expression", "symbols": ["parentheses_open", "_", "parentheses_close"], "postprocess":  d => ({location: {start: d[0].location.start, end: d[2].location.start + 1, },type: 'ParenthesizedExpression', expression: {
+          type: 'EmptyExpression',
+          location: {
+            start: d[0].location.start + 1,
+            end: d[0].location.start + 1,
+          },
+        }}) },
     {"name": "one_op_logical_expression", "symbols": ["parentheses_open", "_", "two_op_logical_expression", "_", "parentheses_close"], "postprocess": d => ({location: {start: d[0].location.start, end: d[4].location.start + 1, },type: 'ParenthesizedExpression', expression: d[2]})},
     {"name": "one_op_logical_expression$string$1", "symbols": [{"literal":"N"}, {"literal":"O"}, {"literal":"T"}], "postprocess": (d) => d.join('')},
     {"name": "one_op_logical_expression", "symbols": ["one_op_logical_expression$string$1", "post_boolean_primary"], "postprocess":  (data, start) => {

--- a/src/internalFilter.ts
+++ b/src/internalFilter.ts
@@ -33,6 +33,12 @@ const createValueTest = (ast: HydratedAst): InternalTest => {
     };
   }
 
+  if (expression.type === 'EmptyExpression') {
+    return () => {
+      return false;
+    };
+  }
+
   const expressionValue = expression.value;
 
   if (ast.operator && ast.operator.operator !== ':') {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -16,6 +16,16 @@ const rules = nearley.Grammar.fromCompiled(grammar);
 const MESSAGE_RULE = /Syntax error at line (?<line>\d+) col (?<column>\d+)/;
 
 export const parse = (query: string): HydratedAst => {
+  if (query.trim() === '') {
+    return {
+      location: {
+        end: 0,
+        start: 0,
+      },
+      type: 'EmptyExpression',
+    };
+  }
+
   const parser = new nearley.Parser(rules);
 
   let results;

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -106,5 +106,9 @@ export const serialize = (ast: HydratedAst): string => {
     return (ast.operator === 'NOT' ? 'NOT ' : ast.operator) + serialize(ast.operand);
   }
 
+  if (ast.type === 'EmptyExpression') {
+    return '';
+  }
+
   throw new Error('Unexpected AST type.');
 };

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -39,6 +39,10 @@ const serializeExpression = (expression: ExpressionToken) => {
     return `${minInclusive ? '[' : '{'}${min} TO ${max}${maxInclusive ? ']' : '}'}`;
   }
 
+  if (expression.type === 'EmptyExpression') {
+    return '';
+  }
+
   throw new Error('Unexpected AST type.');
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export type ParenthesizedExpressionToken = {
   type: 'ParenthesizedExpression',
 };
 
-export type ParserAst = LogicalExpressionToken | ParenthesizedExpressionToken | TagToken | UnaryOperatorToken;
+export type ParserAst = EmptyExpression | LogicalExpressionToken | ParenthesizedExpressionToken | TagToken | UnaryOperatorToken;
 
 export type HydratedAst = ParserAst & {
   getValue?: (subject: unknown) => unknown,

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,7 +57,12 @@ export type LiteralExpressionToken = {
   }
 );
 
-export type ExpressionToken = LiteralExpressionToken | RangeExpressionToken | RegexExpressionToken;
+export type EmptyExpression = {
+  location: TokenLocation,
+  type: 'EmptyExpression',
+};
+
+export type ExpressionToken = EmptyExpression | LiteralExpressionToken | RangeExpressionToken | RegexExpressionToken;
 
 export type BooleanOperatorToken = {
   location: TokenLocation,

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -29,7 +29,36 @@ test('error describes offset', (t) => {
 // Ideally we don't want to throw an error.
 // https://github.com/gajus/liqe/issues/18
 test.todo('empty query');
-test.todo('()');
+
+test('()', testQuery, {
+  expression: {
+    location: {
+      end: 1,
+      start: 1,
+    },
+    type: 'EmptyExpression',
+  },
+  location: {
+    end: 2,
+    start: 0,
+  },
+  type: 'ParenthesizedExpression',
+});
+
+test('( )', testQuery, {
+  expression: {
+    location: {
+      end: 1,
+      start: 1,
+    },
+    type: 'EmptyExpression',
+  },
+  location: {
+    end: 3,
+    start: 0,
+  },
+  type: 'ParenthesizedExpression',
+});
 
 test('foo:', testQuery, {
   expression: {
@@ -61,7 +90,7 @@ test('foo:', testQuery, {
     operator: ':',
     type: 'ComparisonOperator',
   },
-  type: 'TagExpression',
+  type: 'Tag',
 });
 
 test('foo', testQuery, {

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -25,10 +25,25 @@ test('error describes offset', (t) => {
   t.is(error.column, 5);
 });
 
-// TODO not clear what the expected behavior is here
-// Ideally we don't want to throw an error.
-// https://github.com/gajus/liqe/issues/18
-test.todo('empty query');
+test('empty query', (t) => {
+  t.deepEqual(parse(''), {
+    location: {
+      end: 0,
+      start: 0,
+    },
+    type: 'EmptyExpression',
+  });
+});
+
+test('empty query (whitespace)', (t) => {
+  t.deepEqual(parse('  '), {
+    location: {
+      end: 0,
+      start: 0,
+    },
+    type: 'EmptyExpression',
+  });
+});
 
 test('()', testQuery, {
   expression: {

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -30,7 +30,39 @@ test('error describes offset', (t) => {
 // https://github.com/gajus/liqe/issues/18
 test.todo('empty query');
 test.todo('()');
-test.todo('foo:');
+
+test('foo:', testQuery, {
+  expression: {
+    location: {
+      end: 4,
+      start: 4,
+    },
+    type: 'EmptyExpression',
+  },
+  field: {
+    location: {
+      end: 3,
+      start: 0,
+    },
+    name: 'foo',
+    path: ['foo'],
+    quoted: false,
+    type: 'Field',
+  },
+  location: {
+    end: 4,
+    start: 0,
+  },
+  operator: {
+    location: {
+      end: 4,
+      start: 3,
+    },
+    operator: ':',
+    type: 'ComparisonOperator',
+  },
+  type: 'TagExpression',
+});
 
 test('foo', testQuery, {
   expression: {

--- a/test/liqe/serialize.ts
+++ b/test/liqe/serialize.ts
@@ -12,6 +12,10 @@ const testQuery = (t) => {
 
 test('foo', testQuery);
 
+test('()', testQuery);
+
+test('( )', testQuery);
+
 test('foo:', testQuery);
 
 test('foo bar', testQuery);

--- a/test/liqe/serialize.ts
+++ b/test/liqe/serialize.ts
@@ -12,6 +12,8 @@ const testQuery = (t) => {
 
 test('foo', testQuery);
 
+test('foo:', testQuery);
+
 test('foo bar', testQuery);
 
 test('foo AND bar [multiple spaces]', (t) => {

--- a/test/liqe/serialize.ts
+++ b/test/liqe/serialize.ts
@@ -10,6 +10,10 @@ const testQuery = (t) => {
   t.is(serialize(parse(t.title)), t.title);
 };
 
+test('empty query', (t) => {
+  t.is(serialize(parse('')), '');
+});
+
 test('foo', testQuery);
 
 test('()', testQuery);


### PR DESCRIPTION
Allows:

* empty query
* `()`
* `foo:`