### PR TITLE
Fix example for highlight function in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ test(parse('name:David'), persons[0]);
 Highlight matching fields and substrings:
 
 ```ts
-test(highlight('name:john'), persons[0]);
+highlight(parse('name:john'), persons[0]);
 // [
 //   {
 //     path: 'name',
 //     query: /(John)/,
 //   }
 // ]
-test(highlight('height:180'), persons[0]);
+highlight(parse('height:180'), persons[0]);
 // [
 //   {
 //     path: 'height',


### PR DESCRIPTION
Thank you for creating this library, it's very useful! I noticed the Readme gives the example for the highlight function as
```js
test(highlight('name:john'), persons[0]);
```
which doesn't match [its signature](https://github.com/gajus/liqe/blob/efb877db58b8926c20b29ba8b30b075b25af0992/src/highlight.ts#L18). It should instead be
```js
highlight(parse('name:john'), persons[0]);
```