### PR TITLE
fix: allow unquoted terms with numbers (e.g. `foo123`)

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -292,4 +292,4 @@ regex_flags ->
   [gmiyusd]:+ {% d => d[0].join('') %}
 
 unquoted_value ->
-  [a-zA-Z_*?@#$] [a-zA-Z\.\-_*?@#$]:* {% d => d[0] + d[1].join('') %}
+  [a-zA-Z_*?@#$] [a-zA-Z0-9\.\-_*?@#$]:* {% d => d[0] + d[1].join('') %}

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -299,7 +299,7 @@ const grammar: Grammar = {
     {"name": "regex_flags$ebnf$1", "symbols": ["regex_flags$ebnf$1", /[gmiyusd]/], "postprocess": (d) => d[0].concat([d[1]])},
     {"name": "regex_flags", "symbols": ["regex_flags$ebnf$1"], "postprocess": d => d[0].join('')},
     {"name": "unquoted_value$ebnf$1", "symbols": []},
-    {"name": "unquoted_value$ebnf$1", "symbols": ["unquoted_value$ebnf$1", /[a-zA-Z\.\-_*?@#$]/], "postprocess": (d) => d[0].concat([d[1]])},
+    {"name": "unquoted_value$ebnf$1", "symbols": ["unquoted_value$ebnf$1", /[a-zA-Z0-9\.\-_*?@#$]/], "postprocess": (d) => d[0].concat([d[1]])},
     {"name": "unquoted_value", "symbols": [/[a-zA-Z_*?@#$]/, "unquoted_value$ebnf$1"], "postprocess": d => d[0] + d[1].join('')}
   ],
   ParserStart: "main",

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -128,6 +128,26 @@ test('foo', testQuery, {
   type: 'Tag',
 });
 
+test('foo123', testQuery, {
+  expression: {
+    location: {
+      end: 6,
+      start: 0,
+    },
+    quoted: false,
+    type: 'LiteralExpression',
+    value: 'foo123',
+  },
+  field: {
+    type: 'ImplicitField',
+  },
+  location: {
+    end: 6,
+    start: 0,
+  },
+  type: 'Tag',
+});
+
 test('foo with whitespace at the start', (t) => {
   t.deepEqual(parse(' foo'), {
     expression: {
@@ -479,6 +499,41 @@ test('foo:bar@baz.com', testQuery, {
   },
   location: {
     end: 15,
+    start: 0,
+  },
+  operator: {
+    location: {
+      end: 4,
+      start: 3,
+    },
+    operator: ':',
+    type: 'ComparisonOperator',
+  },
+  type: 'Tag',
+});
+
+test('foo:bar123', testQuery, {
+  expression: {
+    location: {
+      end: 10,
+      start: 4,
+    },
+    quoted: false,
+    type: 'LiteralExpression',
+    value: 'bar123',
+  },
+  field: {
+    location: {
+      end: 3,
+      start: 0,
+    },
+    name: 'foo',
+    path: ['foo'],
+    quoted: false,
+    type: 'Field',
+  },
+  location: {
+    end: 10,
     start: 0,
   },
   operator: {


### PR DESCRIPTION
Fixes #32 