### PR TITLE
Fix for issue #37: allow hyphens in field names

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -193,7 +193,7 @@ tag_expression ->
   } %}
 
 field ->
-    [_a-zA-Z$] [a-zA-Z\d_$.]:* {% (data, start) => ({type: 'LiteralExpression', name: data[0] + data[1].join(''), quoted: false, location: {start, end: start + (data[0] + data[1].join('')).length}}) %}
+    [_a-zA-Z$] [a-zA-Z\d_$.-]:* {% (data, start) => ({type: 'LiteralExpression', name: data[0] + data[1].join(''), quoted: false, location: {start, end: start + (data[0] + data[1].join('')).length}}) %}
   | sqstring {% (data, start) => ({type: 'LiteralExpression', name: data[0], quoted: true, quotes: 'single', location: {start, end: start + data[0].length + 2}}) %}
   | dqstring {% (data, start) => ({type: 'LiteralExpression', name: data[0], quoted: true, quotes: 'double', location: {start, end: start + data[0].length + 2}}) %}
 

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -490,7 +490,7 @@ const grammar: Grammar = {
     {
       name: 'field$ebnf$1',
       postprocess: (d) => d[0].concat([d[1]]),
-      symbols: ['field$ebnf$1', /[\w$.]/],
+      symbols: ['field$ebnf$1', /[\w$.-]/],
     },
     {
       name: 'field',

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -2669,3 +2669,38 @@ test('( foo OR bar AND baz )', testQuery, {
   location: { end: 22, start: 0 },
   type: 'ParenthesizedExpression',
 });
+
+test("attrs.user-id:12345", testQuery, {
+  expression: {
+    location: {
+      end: 19,
+      start: 14,
+    },
+    quoted: false,
+    type: "LiteralExpression",
+    value: 12345,
+  },
+  field: {
+    location: {
+      end: 13,
+      start: 0,
+    },
+    name: "attrs.user-id",
+    path: ["attrs", "user-id"],
+    quoted: false,
+    type: "Field",
+  },
+  location: {
+    end: 19,
+    start: 0,
+  },
+  operator: {
+    location: {
+      end: 14,
+      start: 13,
+    },
+    operator: ":",
+    type: "ComparisonOperator",
+  },
+  type: "Tag",
+});


### PR DESCRIPTION
## Summary:
fix for issue #37 where field names containing hyphens like attrs.user-id throw a SyntaxError.

## Changes Made
- updated the grammar rule for field names to include hyphens by modified the field rule in grammer.ne
- i added test case for hyphenated field names in test/liqe/parse.ts