### PR TITLE
fix: fix isSafePath regex

### DIFF
--- a/src/isSafePath.ts
+++ b/src/isSafePath.ts
@@ -1,4 +1,4 @@
-const SAFE_PATH_RULE = /^(\.(?:[_a-zA-Z]\w*|\0|[1-9]\d*))+$/u;
+const SAFE_PATH_RULE = /^(\.(?:[_a-zA-Z]\w*|0|[1-9]\d*))+$/u;
 
 export const isSafePath = (path: string): boolean => {
   return SAFE_PATH_RULE.test(path);

--- a/test/liqe/isSafePath.ts
+++ b/test/liqe/isSafePath.ts
@@ -19,6 +19,7 @@ test('.foo0.bar1', testPath, true);
 
 test('.1', testPath, true);
 test('.10', testPath, true);
+test('.0', testPath, true);
 
 test('foo', testPath, false);
 test('.foo..bar', testPath, false);
@@ -27,3 +28,4 @@ test('.foo[0]', testPath, false);
 
 test('.00', testPath, false);
 test('.01', testPath, false);
+test('.\u0000', testPath, false);


### PR DESCRIPTION
Replaced `\0` with `0` to accept `.0` and reject paths containing null bytes.