### PR TITLE
fix: support ISO 8601 date, date-time, and 24-hour ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,29 @@ Search for value greater than 100 and lower than 200 in the `height` field.
 height:{100 TO 200}
 ```
 
+Ranges also work with non-numeric values whose lexical ordering matches their chronological ordering: ISO 8601 dates, UTC date-times, and 24-hour times. The boundaries must be quoted, and inclusive (`[ ]`) and exclusive (`{ }`) brackets behave the same as for numbers.
+
+Search for dates from the start to the end of 2020, inclusive of both boundaries.
+
+```rb
+created:["2020-01-01" TO "2020-12-31"]
+```
+
+Search for dates strictly between the two boundaries, exclusive.
+
+```rb
+created:{"2020-01-01" TO "2020-12-31"}
+```
+
+UTC date-times and 24-hour times use the same syntax (and the same bracket rules).
+
+```rb
+created:["2020-01-01T00:00:00.000Z" TO "2021-01-01T00:00:00.000Z"]
+startTime:["09:00" TO "17:00"]
+```
+
+Only these canonical, big-endian formats are accepted, because that is what makes lexical ordering equal chronological ordering. A range whose boundaries are anything else — free text, `DD-MM-YYYY`, timezone offsets, lowercase `z`, or mismatched precision — throws a `TypeError`.
+
 ### Wildcard matching
 
 Search for any word that starts with "foo" in the `name` field.

--- a/src/assertSupportedRange.ts
+++ b/src/assertSupportedRange.ts
@@ -1,0 +1,71 @@
+import { type Range } from './types';
+
+// Non-numeric ranges are supported only for value formats whose lexical
+// (character-by-character) ordering matches their chronological ordering. That
+// requires big-endian ISO 8601 layouts (most-significant component first):
+//   - calendar date: YYYY-MM-DD
+//   - UTC date-time:  YYYY-MM-DDTHH:mm:ss[.sss]Z (uppercase "Z" only)
+//   - clock time:     HH:mm[:ss] (24-hour)
+// Little-/middle-endian dates such as DD-MM-YYYY or MM-DD-YYYY are intentionally
+// NOT supported: sorting them lexically would order by day/month before year,
+// which is chronologically wrong. Timezone offsets, lowercase "z", mixed
+// precision, and mismatched boundary types are rejected for the same reason, so
+// a range never returns a silently wrong result.
+// https://github.com/gajus/liqe/issues/3
+const MONTH = '(0[1-9]|1[0-2])';
+const DAY = '(0[1-9]|[12]\\d|3[01])';
+const HOUR = '([01]\\d|2[0-3])';
+const MINUTE_SECOND = '[0-5]\\d';
+
+const ISO_DATE = new RegExp(`^\\d{4}-${MONTH}-${DAY}$`, 'u');
+const ISO_UTC_DATE_TIME = new RegExp(
+  `^\\d{4}-${MONTH}-${DAY}T${HOUR}:${MINUTE_SECOND}:${MINUTE_SECOND}(\\.\\d{3})?Z$`,
+  'u',
+);
+const ISO_TIME = new RegExp(
+  `^${HOUR}:${MINUTE_SECOND}(:${MINUTE_SECOND})?$`,
+  'u',
+);
+
+const RANGE_ERROR_MESSAGE =
+  'Expected a number, ISO 8601 date, UTC date-time, or 24-hour time.';
+
+const detectRangeStringFormat = (
+  value: string,
+): 'date' | 'datetime' | 'time' | null => {
+  if (ISO_DATE.test(value)) {
+    return 'date';
+  }
+
+  if (ISO_UTC_DATE_TIME.test(value)) {
+    return 'datetime';
+  }
+
+  if (ISO_TIME.test(value)) {
+    return 'time';
+  }
+
+  return null;
+};
+
+export const assertSupportedRange = (range: Range): void => {
+  const { max, min } = range;
+
+  if (typeof min === 'number' && typeof max === 'number') {
+    return;
+  }
+
+  if (typeof min !== 'string' || typeof max !== 'string') {
+    throw new TypeError(RANGE_ERROR_MESSAGE);
+  }
+
+  const minFormat = detectRangeStringFormat(min);
+  const maxFormat = detectRangeStringFormat(max);
+
+  // Both boundaries must share a supported format and identical width, so that
+  // e.g. "…00.00Z" TO "…00.000Z" (mismatched precision) is rejected rather than
+  // lexically compared against differently-shaped values.
+  if (!minFormat || minFormat !== maxFormat || min.length !== max.length) {
+    throw new TypeError(RANGE_ERROR_MESSAGE);
+  }
+};

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -237,7 +237,7 @@ expression ->
   | dqstring {% (data, start) => ({type: 'Tag', expression: {location: {start, end: start + data.join('').length + 2}, type: 'LiteralExpression', quoted: true, quotes: 'double', value: data.join('')}}) %}
 
 range ->
-    range_open decimal " TO " decimal range_close {% (data, start) => {
+    range_open range_value " TO " range_value range_close {% (data, start) => {
     return {
       location: {
         start,
@@ -266,6 +266,14 @@ range_open ->
 range_close ->
   "]" {% (data, start) => ({location: {start}, inclusive: true}) %}
   | "}" {% (data, start) => ({location: {start}, inclusive: false}) %}
+
+# Range boundaries can be numeric (decimal) or a quoted string. Quoted-string
+# boundaries are compared lexically, which makes ISO 8601 date/datetime and other
+# canonically-ordered string ranges work. See https://github.com/gajus/liqe/issues/3
+range_value ->
+    decimal  {% id %}
+  | dqstring {% id %}
+  | sqstring {% id %}
 
 comparison_operator ->
     (

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -649,9 +649,9 @@ const grammar: Grammar = {
       },
       symbols: [
         'range_open',
-        'decimal',
+        'range_value',
         'range$string$1',
-        'decimal',
+        'range_value',
         'range_close',
       ],
     },
@@ -675,6 +675,9 @@ const grammar: Grammar = {
       postprocess: (data, start) => ({ inclusive: false, location: { start } }),
       symbols: [{ literal: '}' }],
     },
+    { name: 'range_value', postprocess: id, symbols: ['decimal'] },
+    { name: 'range_value', postprocess: id, symbols: ['dqstring'] },
+    { name: 'range_value', postprocess: id, symbols: ['sqstring'] },
     {
       name: 'comparison_operator$subexpression$1',
       symbols: [{ literal: ':' }],

--- a/src/internalFilter.ts
+++ b/src/internalFilter.ts
@@ -1,3 +1,4 @@
+import { assertSupportedRange } from './assertSupportedRange';
 import { createStringTest } from './createStringTest';
 import { testComparisonRange } from './testComparisonRange';
 import { testRange } from './testRange';
@@ -15,6 +16,8 @@ const createValueTest = (ast: LiqeQuery): InternalTest => {
   const { expression } = ast;
 
   if (expression.type === 'RangeExpression') {
+    assertSupportedRange(expression.range);
+
     return (value) => {
       return testRange(value, expression.range);
     };

--- a/src/testRange.ts
+++ b/src/testRange.ts
@@ -1,7 +1,11 @@
 import { type Range } from './types';
 
 export const testRange = (value: unknown, range: Range): boolean => {
-  if (typeof value === 'number') {
+  if (
+    typeof value === 'number' &&
+    typeof range.min === 'number' &&
+    typeof range.max === 'number'
+  ) {
     if (value < range.min) {
       return false;
     }
@@ -21,7 +25,32 @@ export const testRange = (value: unknown, range: Range): boolean => {
     return true;
   }
 
-  // @todo handle non-numeric ranges -- https://github.com/gajus/liqe/issues/3
+  // Non-numeric (string) ranges are compared lexically. This makes ISO 8601
+  // date/datetime ranges and other canonically-ordered string ranges work.
+  // https://github.com/gajus/liqe/issues/3
+  if (
+    typeof value === 'string' &&
+    typeof range.min === 'string' &&
+    typeof range.max === 'string'
+  ) {
+    if (value < range.min) {
+      return false;
+    }
+
+    if (value === range.min && !range.minInclusive) {
+      return false;
+    }
+
+    if (value > range.max) {
+      return false;
+    }
+
+    if (value === range.max && !range.maxInclusive) {
+      return false;
+    }
+
+    return true;
+  }
 
   return false;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,9 +105,9 @@ export type ParserAst =
   | UnaryOperatorToken;
 
 export type Range = {
-  max: number;
+  max: number | string;
   maxInclusive: boolean;
-  min: number;
+  min: number | string;
   minInclusive: boolean;
 };
 

--- a/test/liqe/filter.ts
+++ b/test/liqe/filter.ts
@@ -167,3 +167,111 @@ test('(name:fox OR (name:"foo bar" AND nick:"old dog"))', testQuery, [
   'fox',
   'foo bar',
 ]);
+
+// String ranges make ISO 8601 date/datetime and 24-hour time filtering work,
+// because for these canonical forms lexical order == chronological order.
+// https://github.com/gajus/liqe/issues/3
+type Event = {
+  date: string;
+  id: string;
+  startTime: string;
+  timestamp: string;
+};
+
+const events: readonly Event[] = [
+  {
+    date: '2019-06-15',
+    id: 'a',
+    startTime: '08:30',
+    timestamp: '2019-06-15T08:30:00.000Z',
+  },
+  {
+    date: '2020-03-15',
+    id: 'b',
+    startTime: '09:00',
+    timestamp: '2020-03-15T09:00:00.000Z',
+  },
+  {
+    date: '2020-11-30',
+    id: 'c',
+    startTime: '14:15',
+    timestamp: '2020-11-30T14:15:00.000Z',
+  },
+  {
+    date: '2021-12-25',
+    id: 'd',
+    startTime: '17:45',
+    timestamp: '2021-12-25T17:45:00.000Z',
+  },
+];
+
+const testEvents = test.macro((t, expectedIds: string[]) => {
+  const matchingIds = filter(parse(t.title), events).map((event) => {
+    return event.id;
+  });
+
+  t.deepEqual(matchingIds, expectedIds);
+});
+
+// Date-only (YYYY-MM-DD).
+test('date:["2020-01-01" TO "2020-12-31"]', testEvents, ['b', 'c']);
+test('date:{"2019-06-15" TO "2021-12-25"}', testEvents, ['b', 'c']);
+test('date:["2020-03-15" TO "2020-11-30"}', testEvents, ['b']);
+test('date:{"2019-06-15" TO "2020-11-30"]', testEvents, ['b', 'c']);
+
+// Full ISO 8601 datetime (single-timezone, fixed-precision).
+test(
+  'timestamp:["2020-01-01T00:00:00.000Z" TO "2021-01-01T00:00:00.000Z"]',
+  testEvents,
+  ['b', 'c'],
+);
+
+// 24-hour zero-padded time (HH:mm).
+test('startTime:["09:00" TO "17:00"]', testEvents, ['b', 'c']);
+test('startTime:{"09:00" TO "17:00"}', testEvents, ['c']);
+
+// UTC date-times without milliseconds are accepted too, as long as both
+// boundaries share the same shape.
+test('accepts second-precision UTC date-time ranges', (t) => {
+  const rows = [
+    { id: 'x', ts: '2020-06-01T12:00:00Z' },
+    { id: 'y', ts: '2022-06-01T12:00:00Z' },
+  ];
+
+  const matchingIds = filter(
+    parse('ts:["2020-01-01T00:00:00Z" TO "2021-01-01T00:00:00Z"]'),
+    rows,
+  ).map((row) => {
+    return row.id;
+  });
+
+  t.deepEqual(matchingIds, ['x']);
+});
+
+// Ranges whose boundaries are not a supported, consistent date/time format
+// throw a TypeError rather than returning a silently-wrong lexical result.
+const unsupportedRangeQueries = [
+  // Free-text boundaries are not a date/time format.
+  'name:["a" TO "e"]',
+  // Lowercase "z" is not valid ISO 8601 (UTC must be uppercase "Z").
+  'timestamp:["2020-01-01T00:00:00.000z" TO "2021-01-01T00:00:00.000z"]',
+  // Mismatched millisecond precision between the two boundaries.
+  'timestamp:["2020-01-01T00:00:00.00Z" TO "2021-01-01T00:00:00.000Z"]',
+  // Timezone offsets break lexical ordering and are rejected.
+  'timestamp:["2020-01-01T00:00:00.000+05:00" TO "2021-01-01T00:00:00.000+05:00"]',
+  // Mismatched boundary types (number vs string).
+  'date:[1 TO "2020-12-31"]',
+  // Mismatched categories (date vs time).
+  'date:["2020-01-01" TO "17:00"]',
+];
+
+for (const query of unsupportedRangeQueries) {
+  test(`throws TypeError for unsupported range: ${query}`, (t) => {
+    t.throws(
+      () => {
+        return filter(parse(query), events);
+      },
+      { instanceOf: TypeError },
+    );
+  });
+}

--- a/test/liqe/parse.ts
+++ b/test/liqe/parse.ts
@@ -2771,6 +2771,75 @@ test('{1 TO 2}', testQuery, {
   type: 'Tag',
 });
 
+test('["2020-01-01" TO "2020-12-31"]', testQuery, {
+  expression: {
+    location: {
+      end: 30,
+      start: 0,
+    },
+    range: {
+      max: '2020-12-31',
+      maxInclusive: true,
+      min: '2020-01-01',
+      minInclusive: true,
+    },
+    type: 'RangeExpression',
+  },
+  field: {
+    type: 'ImplicitField',
+  },
+  location: {
+    start: 0,
+  },
+  type: 'Tag',
+});
+
+test('{"2020-01-01" TO "2020-12-31"}', testQuery, {
+  expression: {
+    location: {
+      end: 30,
+      start: 0,
+    },
+    range: {
+      max: '2020-12-31',
+      maxInclusive: false,
+      min: '2020-01-01',
+      minInclusive: false,
+    },
+    type: 'RangeExpression',
+  },
+  field: {
+    type: 'ImplicitField',
+  },
+  location: {
+    start: 0,
+  },
+  type: 'Tag',
+});
+
+test("['2020-01-01' TO '2020-12-31']", testQuery, {
+  expression: {
+    location: {
+      end: 30,
+      start: 0,
+    },
+    range: {
+      max: '2020-12-31',
+      maxInclusive: true,
+      min: '2020-01-01',
+      minInclusive: true,
+    },
+    type: 'RangeExpression',
+  },
+  field: {
+    type: 'ImplicitField',
+  },
+  location: {
+    start: 0,
+  },
+  type: 'Tag',
+});
+
 test('( foo OR bar AND baz )', testQuery, {
   expression: {
     left: {


### PR DESCRIPTION
### What problem is this PR solving?

liqe only supports **numeric** range queries (e.g. `height:[100 TO 200]`). Any non-numeric boundary fails — an ISO date such as `created:[2020-01-01 TO 2020-12-31]` throws a `SyntaxError` at parse time, and quoted string boundaries are rejected too.

This PR adds range support for **ISO 8601 dates, UTC date-times, and 24-hour times**, so queries like these filter correctly (inclusive `[ ]` and exclusive `{ }` both supported):

```
created:["2020-01-01" TO "2020-12-31"]
created:["2020-01-01T00:00:00.000Z" TO "2021-01-01T00:00:00.000Z"]
startTime:["09:00" TO "17:00"]
```

Quoted boundaries are compared lexically. Only canonical, big-endian formats are accepted — that is the condition under which lexical ordering equals chronological ordering — so any other boundary (free text, `DD-MM-YYYY`, timezone offsets, lowercase `z`, or mismatched precision) throws a `TypeError`, consistent with liqe's existing `Expected a number.` value error. Numeric ranges and structural `SyntaxError`s are unchanged.

Related to #3 and #8: date and date-time filtering is now possible via ranges; the `:>=` / `:<=` comparison operators shown in #8 are a planned follow-up.

### What is the impact of this PR?

**End users:** can now filter by date / date-time / time ranges using the existing range syntax, with the boundaries quoted.

**Developers / behaviour change:** a string range whose boundaries are not a supported, consistent format now throws a `TypeError` at filter time (previously such input either failed to parse or matched nothing). Numeric ranges are unaffected, and there is no change to the public API surface (the new validation is internal).

**Data requirement:** lexical comparison equals chronological comparison only for canonical values — single-timezone UTC (`Z`), fixed width, big-endian ISO. Non-canonical inputs (12-hour times, `DD-MM-YYYY`, local offsets) must be normalised before querying.
